### PR TITLE
Use increment-less for-loop instead of while

### DIFF
--- a/spt.c
+++ b/spt.c
@@ -137,8 +137,8 @@ main(int argc, char *argv[])
 			if (suspend)
 				pause();
 			else {
-				sleep(1);
 				timecount++;
+				sleep(1);
 			}
 	}
 

--- a/spt.c
+++ b/spt.c
@@ -132,8 +132,8 @@ main(int argc, char *argv[])
 
 	for (i = 0; ; i = (i + 1) % LEN(timers)) {
 		notify_send(timers[i].cmt);
-		timecount = 0;
-		while (timecount < timers[i].tmr)
+
+		for (timecount = 0; timecount < timers[i].tmr;)
 			if (suspend)
 				pause();
 			else {


### PR DESCRIPTION
For conciseness, readability and counter logic, a for-loop may be better
than a while.

I tried over-think how we may use time(2) logic, recording start time and/or end time, computing the remaining time, sleep(3)ing for this period, saving time state before and after suspend, etc, in order to have a better while logic. 

But finally, I think the sleep(3) for 1 second is really fine, so this patch is more aesthetic and more related to the logic of a for-loop counter.
