### PR TITLE
Add notification wrapper script for MacOS

### DIFF
--- a/contrib/notify-macos
+++ b/contrib/notify-macos
@@ -1,0 +1,6 @@
+#!/bin/sh
+# A notification wrapper for MacOS. It will appear in Notification
+# Center as owned by Script Editor.
+#
+# usage: spt -n ./notify-macos
+osascript -e "display notification \"$2\" with title \"$1\""


### PR DESCRIPTION
If you compile this without `libnotify` you can then use this script on MacOS to get the notifications. This might be more useful in a manual somewhere than in the repository.