### PR TITLE
Announce the state on suspend

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -15,6 +15,9 @@ DEFS = -DNOTIFY
 INCS+= `pkg-config --cflags libnotify`
 LIBS+= `pkg-config --libs libnotify`
 
+# set to 1 to display state on toggle
+DEFS+= -DDISPLAY_TOGGLE=0
+
 # flags
 CPPFLAGS = -DVERSION=\"${VERSION}\" -D_POSIX_C_SOURCE=199309
 CFLAGS += -g -std=c99 -pedantic -Wall -Os ${INCS} ${DEFS} ${CPPFLAGS}

--- a/spt.1
+++ b/spt.1
@@ -20,7 +20,7 @@ receives 2 signals:
 \- show remaining time, state
 .br
 .B SIGUSR2()
-\- play/pause the timer
+\- same as above and play/pause the timer
 .RE
 .SH OPTIONS
 .TP

--- a/spt.1
+++ b/spt.1
@@ -20,7 +20,7 @@ receives 2 signals:
 \- show remaining time, state
 .br
 .B SIGUSR2()
-\- same as above and play/pause the timer
+\- same as above and/or play/pause the timer (specified at compile time)
 .RE
 .SH OPTIONS
 .TP

--- a/spt.c
+++ b/spt.c
@@ -118,7 +118,7 @@ main(int argc, char *argv[])
 	struct timespec remaining;
 	struct sigaction sa;
 	sigset_t emptymask;
-	int i;
+	int i, prevsuspend;
 
 	ARGBEGIN {
 		case 'e':
@@ -133,6 +133,8 @@ main(int argc, char *argv[])
 		default:
 			usage();
 	} ARGEND;
+
+	prevsuspend = suspend = 0;
 
 	/* add SIGUSR1 handler: remaining_time */
 	sa.sa_handler = toggle_display;
@@ -157,8 +159,11 @@ main(int argc, char *argv[])
 		remaining.tv_sec = timers[i].tmr;
 		remaining.tv_nsec = 0;
 		while (remaining.tv_sec) {
-			if (display)
+			if (display || prevsuspend != suspend) {
 				display_state(remaining.tv_sec, suspend);
+
+				prevsuspend = suspend;
+			}
 
 			if (suspend)
 				sigsuspend(&emptymask);

--- a/spt.c
+++ b/spt.c
@@ -159,7 +159,7 @@ main(int argc, char *argv[])
 		remaining.tv_sec = timers[i].tmr;
 		remaining.tv_nsec = 0;
 		while (remaining.tv_sec) {
-			if (display || prevsuspend != suspend) {
+			if (display || (prevsuspend != suspend && DISPLAY_TOGGLE)) {
 				display_state(remaining.tv_sec, suspend);
 
 				prevsuspend = suspend;


### PR DESCRIPTION
When `SIGUSR2` is passed, it's unclear in what state spt is until you pass `SIGUSR1` afterwards.

So make it clear in the first place.