### PR TITLE
Add a missing dependency edge to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ options:
 
 ${OBJ}: config.h config.mk
 
-config.h:
+config.h: config.def.h
 	@echo creating $@ from config.def.h
 	@cp config.def.h $@
 


### PR DESCRIPTION
Well, this is an obvious change.
If this missing dependency is not a feature, of course.

Edit: hmm, this might well be a feature. So you are supposed to have a customized config.h, and config.def.h is only used if you don't, right?