### PR TITLE
modify spawn() to avoid creation of orphan processes

### DIFF
--- a/spt.c
+++ b/spt.c
@@ -51,12 +51,19 @@ die(const char *errstr, ...)
 void
 spawn(char *cmd, char *cmt)
 {
-	if (fork() == 0) {
-		setsid();
-		execlp(cmd, cmd, "spt", cmt, NULL);
-		die("spt: execlp %s\n", cmd);
-		perror(" failed");
-		exit(0);
+	pid_t childid = fork();
+	if (childid == 0) {
+		if(fork() == 0) {
+			setsid();
+			execlp(cmd, cmd, cmt, NULL);
+			die("spt: execlp %s\n", cmd);
+			perror(" failed");
+			exit(0);
+		} else {
+			_exit(EXIT_SUCCESS);
+		}
+	} else {
+		waitpid(childid, NULL, 0);
 	}
 }
 

--- a/spt.c
+++ b/spt.c
@@ -60,7 +60,7 @@ spawn(char *cmd, char *cmt)
 			perror(" failed");
 			exit(0);
 		} else {
-			_exit(EXIT_SUCCESS);
+			exit(0);
 		}
 	} else {
 		waitpid(childid, NULL, 0);


### PR DESCRIPTION
- when some cmd is spawned and fails, it ends up becoming an orphan
process.
- this fix avoids that by adding one extra fork and waiting for the
child.