### PR TITLE
Fix man page for -e.

### DIFF
--- a/spt.1
+++ b/spt.1
@@ -26,7 +26,7 @@ receives 2 signals:
 .TP
 .BI \-e " notifyext"
 Execute
-.I notifycmd
+.I notifyext
 when timer starts ticking.
 .TP
 .BI \-n " notifycmd"


### PR DESCRIPTION
Maybe we should document for the none programmer, that currently, if
notifycmd is set, the -DNOTIFY part is skipped.